### PR TITLE
Move refresh button to own profile page, PWA-only

### DIFF
--- a/src/components/shared/AppLayout.tsx
+++ b/src/components/shared/AppLayout.tsx
@@ -2,7 +2,6 @@ import { Outlet } from 'react-router-dom'
 import { Toaster } from 'sonner'
 
 import { MobileBottomNav } from '@/components/shared/MobileBottomNav'
-import { RefreshButton } from '@/components/shared/RefreshButton'
 import { Sidebar } from '@/components/shared/Sidebar'
 
 export function AppLayout() {
@@ -11,9 +10,6 @@ export function AppLayout() {
       <Sidebar className="hidden md:flex" />
       <div className="flex flex-1 flex-col md:ml-14 lg:ml-56">
         <main className="flex-1 p-6 pb-[calc(6rem+env(safe-area-inset-bottom))] md:pb-6">
-          <div className="mb-3 flex justify-end">
-            <RefreshButton />
-          </div>
           <Outlet />
         </main>
       </div>

--- a/src/features/standings/PlayerProfilePage.tsx
+++ b/src/features/standings/PlayerProfilePage.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link, useParams } from 'react-router-dom'
 
+import { RefreshButton } from '@/components/shared/RefreshButton'
 import {
   Card,
   CardContent,
@@ -9,10 +10,18 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { useAuth } from '@/features/auth/AuthProvider'
 import EloHistoryChart from '@/features/standings/EloHistoryChart'
 import { getLeague, getMembershipsByUser, getUser } from '@/lib/firestore'
 import { formatRecord } from '@/lib/format'
 import type { League, Membership, User } from '@/types'
+
+function isPwa(): boolean {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as Navigator & { standalone?: boolean }).standalone === true
+  )
+}
 
 interface ProfileData {
   user: User
@@ -34,6 +43,7 @@ async function fetchProfile(uid: string): Promise<ProfileData | null> {
 
 export default function PlayerProfilePage() {
   const { uid } = useParams<{ uid: string }>()
+  const { user: currentUser } = useAuth()
   const { data, isLoading } = useQuery({
     queryKey: ['profile', uid],
     queryFn: () => (uid ? fetchProfile(uid) : Promise.resolve(null)),
@@ -54,16 +64,21 @@ export default function PlayerProfilePage() {
 
   const { user, entries } = data
 
+  const showRefresh = currentUser?.uid === uid && isPwa()
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">
-          {user.displayName || user.email || 'Unknown player'}
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          Global ELO {user.globalElo} ·{' '}
-          {formatRecord(user.globalWins, user.globalLosses)}
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">
+            {user.displayName || user.email || 'Unknown player'}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Global ELO {user.globalElo} ·{' '}
+            {formatRecord(user.globalWins, user.globalLosses)}
+          </p>
+        </div>
+        {showRefresh && <RefreshButton />}
       </div>
 
       <Card>


### PR DESCRIPTION
Removes the global RefreshButton from every page in AppLayout and
re-adds it exclusively on PlayerProfilePage when the viewer is the
authenticated user and the app is running in PWA standalone mode.

https://claude.ai/code/session_01FFwp5DRp38ARn4N79BAoQN