### PR TITLE
Game card padding, detail modal, ELO preview labels, top-3 standings

### DIFF
--- a/src/features/games/GameHistoryList.tsx
+++ b/src/features/games/GameHistoryList.tsx
@@ -24,6 +24,9 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from '@/components/ui/dialog'
 import {
   DropdownMenu,
@@ -48,7 +51,7 @@ export default function GameHistoryList({ leagueId }: { leagueId: string }) {
   const { user } = useAuth()
 
   const [pendingDelete, setPendingDelete] = useState<Game | null>(null)
-  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null)
+  const [selectedGame, setSelectedGame] = useState<Game | null>(null)
   const [busy, setBusy] = useState(false)
 
   const displayName = (uid: string): string => {
@@ -106,12 +109,13 @@ export default function GameHistoryList({ leagueId }: { leagueId: string }) {
   return (
     <>
       <Card>
-        <CardContent className="pt-6">
+        <CardContent className="px-6 pt-2 pb-3">
           <ul className="divide-y">
             {games.map((game) => (
               <li
                 key={game.id}
-                className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between"
+                onClick={() => setSelectedGame(game)}
+                className="flex cursor-pointer flex-col gap-2 py-2 transition-colors hover:opacity-80 sm:flex-row sm:items-center sm:justify-between"
               >
                 <div className="flex min-w-0 flex-col gap-1">
                   <span className="text-sm">
@@ -131,17 +135,11 @@ export default function GameHistoryList({ leagueId }: { leagueId: string }) {
                       : 'just now'}
                   </span>
                   {game.photoUrl && (
-                    <button
-                      type="button"
-                      onClick={() => setLightboxUrl(game.photoUrl!)}
-                      className="w-fit rounded-md border p-0.5 transition-opacity hover:opacity-80"
-                    >
-                      <img
-                        src={game.photoUrl}
-                        alt="Game photo"
-                        className="h-12 w-12 rounded object-cover"
-                      />
-                    </button>
+                    <img
+                      src={game.photoUrl}
+                      alt="Game photo"
+                      className="h-12 w-12 rounded border object-cover"
+                    />
                   )}
                 </div>
                 <div className="flex items-center gap-3 font-mono text-xs">
@@ -153,6 +151,7 @@ export default function GameHistoryList({ leagueId }: { leagueId: string }) {
                         variant="ghost"
                         size="icon"
                         className="h-7 w-7"
+                        onClick={(e) => e.stopPropagation()}
                       >
                         <MoreHorizontal className="h-4 w-4" />
                       </Button>
@@ -215,16 +214,57 @@ export default function GameHistoryList({ leagueId }: { leagueId: string }) {
       </AlertDialog>
 
       <Dialog
-        open={lightboxUrl !== null}
-        onOpenChange={(o) => !o && setLightboxUrl(null)}
+        open={selectedGame !== null}
+        onOpenChange={(o) => !o && setSelectedGame(null)}
       >
-        <DialogContent className="max-w-3xl">
-          {lightboxUrl && (
-            <img
-              src={lightboxUrl}
-              alt="Game photo"
-              className="w-full rounded-md object-contain"
-            />
+        <DialogContent className="max-w-lg p-0 overflow-hidden">
+          {selectedGame && (
+            <>
+              {selectedGame.photoUrl && (
+                <img
+                  src={selectedGame.photoUrl}
+                  alt="Game photo"
+                  className="w-full object-contain max-h-72"
+                />
+              )}
+              <div className="px-6 pt-4 pb-6 space-y-4">
+                <DialogHeader>
+                  <DialogTitle>
+                    {formatTeam(selectedGame.winnerIds, displayName)} defeated{' '}
+                    {formatTeam(selectedGame.loserIds, displayName)}
+                  </DialogTitle>
+                  <DialogDescription>
+                    {selectedGame.playedAt
+                      ? formatDistanceToNow(selectedGame.playedAt.toDate(), {
+                          addSuffix: true,
+                        })
+                      : 'just now'}
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-1.5">
+                  {[...selectedGame.winnerIds, ...selectedGame.loserIds].map((uid) => {
+                    const snap = selectedGame.playerElo[uid]
+                    const isWinner = selectedGame.winnerIds.includes(uid)
+                    if (!snap) return null
+                    return (
+                      <div key={uid} className="flex items-center justify-between gap-2">
+                        <span className={`truncate text-xs font-medium${isWinner ? '' : ' text-muted-foreground'}`}>
+                          {displayName(uid)}
+                        </span>
+                        <div className="flex gap-3 font-mono text-xs">
+                          <span className={deltaColorClass(snap.globalBefore, snap.globalAfter)}>
+                            G {formatDelta(snap.globalBefore, snap.globalAfter)}
+                          </span>
+                          <span className={deltaColorClass(snap.leagueBefore, snap.leagueAfter)}>
+                            L {formatDelta(snap.leagueBefore, snap.leagueAfter)}
+                          </span>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            </>
           )}
         </DialogContent>
       </Dialog>

--- a/src/features/games/RecordGamePage.tsx
+++ b/src/features/games/RecordGamePage.tsx
@@ -535,7 +535,7 @@ function TeamDeltaBlock({ title, rows }: { title: string; rows: TeamDelta[] }) {
   return (
     <div className="space-y-1">
       <p className="text-xs font-medium text-muted-foreground">{title}</p>
-      <div className="grid grid-cols-[1fr_auto_auto] gap-x-3 gap-y-1 font-mono">
+      <div className="flex flex-col gap-1">
         {rows.map((r) => (
           <RatingRow key={r.uid} row={r} />
         ))}
@@ -546,14 +546,16 @@ function TeamDeltaBlock({ title, rows }: { title: string; rows: TeamDelta[] }) {
 
 function RatingRow({ row }: { row: TeamDelta }) {
   return (
-    <>
-      <span className="truncate text-muted-foreground">{row.name}</span>
-      <span className={deltaColorClass(row.globalBefore, row.globalAfter)}>
-        G {row.globalBefore}→{row.globalAfter} ({formatDelta(row.globalBefore, row.globalAfter)})
-      </span>
-      <span className={deltaColorClass(row.leagueBefore, row.leagueAfter)}>
-        L {row.leagueBefore}→{row.leagueAfter} ({formatDelta(row.leagueBefore, row.leagueAfter)})
-      </span>
-    </>
+    <div className="flex items-center justify-between gap-2">
+      <span className="truncate text-xs font-medium">{row.name}</span>
+      <div className="flex gap-3 font-mono text-xs">
+        <span className={deltaColorClass(row.globalBefore, row.globalAfter)}>
+          G {formatDelta(row.globalBefore, row.globalAfter)}
+        </span>
+        <span className={deltaColorClass(row.leagueBefore, row.leagueAfter)}>
+          L {formatDelta(row.leagueBefore, row.leagueAfter)}
+        </span>
+      </div>
+    </div>
   )
 }

--- a/src/features/home/LeagueSummaryCard.tsx
+++ b/src/features/home/LeagueSummaryCard.tsx
@@ -66,7 +66,7 @@ export function LeagueSummaryCard({
     [members, currentUserId],
   )
 
-  const top = members?.[0] ?? null
+  const top3 = members?.slice(0, 3) ?? []
   const lastGame: Game | null = games?.[0] ?? null
   const recentForUser = useMemo(() => {
     if (!games) return []
@@ -122,24 +122,38 @@ export function LeagueSummaryCard({
             <EloHistoryChart uid={currentUserId} leagueId={league.id} />
           </div>
 
-          <div className="flex items-center gap-2 text-sm">
-            <Trophy className="h-4 w-4 text-primary" />
-            <span className="text-muted-foreground">Top:</span>
-            {top?.user ? (
-              <>
-                <Avatar size="sm">
-                  <AvatarImage src={top.user.photoURL || undefined} />
-                  <AvatarFallback>{initials(name(top))}</AvatarFallback>
-                </Avatar>
-                <span className="font-medium">{name(top)}</span>
-                <span className="font-mono text-muted-foreground">
-                  {top.membership.leagueElo}
-                </span>
-              </>
-            ) : membersLoading ? (
-              <Skeleton className="h-4 w-32" />
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Trophy className="h-3.5 w-3.5" />
+              <span>Standings</span>
+            </div>
+            {membersLoading ? (
+              <Skeleton className="h-16 w-full" />
+            ) : top3.length > 0 ? (
+              top3.map((m, i) => {
+                const medalClass = [
+                  'bg-yellow-400/20 text-yellow-600 dark:text-yellow-400',
+                  'bg-slate-200/60 text-slate-500 dark:text-slate-400',
+                  'bg-orange-400/20 text-orange-600 dark:text-orange-500',
+                ][i]
+                return (
+                  <div key={m.membership.userId} className="flex items-center gap-2 text-sm">
+                    <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold ${medalClass}`}>
+                      {i + 1}
+                    </span>
+                    <Avatar size="sm">
+                      <AvatarImage src={m.user?.photoURL || undefined} />
+                      <AvatarFallback>{initials(name(m))}</AvatarFallback>
+                    </Avatar>
+                    <span className="truncate font-medium">{name(m)}</span>
+                    <span className="ml-auto font-mono text-xs text-muted-foreground">
+                      {m.membership.leagueElo}
+                    </span>
+                  </div>
+                )
+              })
             ) : (
-              <span className="text-muted-foreground">No members yet</span>
+              <span className="text-sm text-muted-foreground">No members yet</span>
             )}
           </div>
 


### PR DESCRIPTION
- GameHistoryList: reduce card vertical padding; clicking a row opens
  a detail modal with photo at top and named per-player ELO deltas;
  ⋯ menu stops propagation
- RecordGamePage: ELO preview shows names prominently with compact
  G/L deltas instead of verbose before→after format
- LeagueSummaryCard: replace single "Top:" row with gold/silver/bronze
  ranked list of up to 3 players

https://claude.ai/code/session_01FFwp5DRp38ARn4N79BAoQN